### PR TITLE
Fix metadata executor job invocation

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -296,9 +296,7 @@ async def _collect_statistics(
         ) from err
 
     metadata = await instance.async_add_executor_job(
-
         partial(recorder_statistics.get_metadata, hass, statistic_ids)
- main
     )
 
     stats_map = await instance.async_add_executor_job(


### PR DESCRIPTION
## Summary
- ensure recorder metadata lookup uses an executor job wrapper that only passes positional arguments

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d3c4bcc6488320a7b33c8d87feee54