### PR TITLE
Fix recorder metadata fetch

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -296,7 +296,11 @@ async def _collect_statistics(
         ) from err
 
     metadata = await instance.async_add_executor_job(
-        partial(recorder_statistics.get_metadata, hass, statistic_ids)
+        partial(
+            recorder_statistics.get_metadata,
+            hass,
+            statistic_ids=statistic_ids,
+        )
     )
 
     stats_map = await instance.async_add_executor_job(


### PR DESCRIPTION
## Summary
- wrap recorder metadata retrieval in functools.partial so the executor job receives a single callable with hass and statistic_ids bound

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d3c95900788320a1810cd2782197ab