### PR TITLE
Add options flow handler for Energy PDF Report integration

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -35,3 +35,33 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Gérer une importation depuis YAML."""
 
         return await self.async_step_user(user_input)
+
+
+class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):
+    """Gérer le flux d'options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialiser la classe."""
+
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Gérer l'étape initiale du flux d'options."""
+
+        if user_input is not None:
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({}),
+        )
+
+
+async def async_get_options_flow(
+    config_entry: config_entries.ConfigEntry,
+) -> EnergyPDFReportOptionsFlowHandler:
+    """Obtenir le gestionnaire du flux d'options."""
+
+    return EnergyPDFReportOptionsFlowHandler(config_entry)

--- a/custom_components/energy_pdf_report/translations/en.json
+++ b/custom_components/energy_pdf_report/translations/en.json
@@ -1,0 +1,9 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "description": "No additional options are available."
+      }
+    }
+  }
+}

--- a/custom_components/energy_pdf_report/translations/fr.json
+++ b/custom_components/energy_pdf_report/translations/fr.json
@@ -1,0 +1,9 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "description": "Aucune option supplémentaire n'est disponible."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an options flow handler that exposes an empty confirmation step
- provide translations so the options flow explains there are no extra settings

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d3cd471198832097dfc97d7ecc03a3