### PR TITLE
Allow reinstalling Energy PDF Report from config flow

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -22,16 +22,75 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Gérer l'étape initiale lancée par l'utilisateur."""
 
         if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
+            return await self.async_step_reinstall_confirm(user_input)
 
         if user_input is not None:
             return self.async_create_entry(title="Rapport PDF Énergie", data={})
 
         return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
 
+    async def async_step_reinstall_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Confirmer la réinstallation en supprimant l'entrée existante."""
+
+        existing_entries = self._async_current_entries()
+        if not existing_entries:
+            return await self.async_step_user(user_input)
+
+        if user_input is not None:
+            removed = await self.hass.config_entries.async_remove(
+                existing_entries[0].entry_id
+            )
+            if not removed:
+                return self.async_abort(reason="remove_failed")
+
+            return await self.async_step_user({})
+
+        return self.async_show_form(
+            step_id="reinstall_confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "title": existing_entries[0].title,
+            },
+        )
+
     async def async_step_import(
         self, user_input: dict[str, Any]
     ) -> config_entries.ConfigFlowResult:
         """Gérer une importation depuis YAML."""
 
-        return await self.async_step_user(user_input)
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        return self.async_create_entry(title="Rapport PDF Énergie", data={})
+
+
+class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):
+    """Gérer le flux d'options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialiser la classe."""
+
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Gérer l'étape initiale du flux d'options."""
+
+        if user_input is not None:
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({}),
+        )
+
+
+async def async_get_options_flow(
+    config_entry: config_entries.ConfigEntry,
+) -> EnergyPDFReportOptionsFlowHandler:
+    """Obtenir le gestionnaire du flux d'options."""
+
+    return EnergyPDFReportOptionsFlowHandler(config_entry)

--- a/custom_components/energy_pdf_report/translations/en.json
+++ b/custom_components/energy_pdf_report/translations/en.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "reinstall_confirm": {
+        "title": "Replace existing Energy PDF Report",
+        "description": "An existing Energy PDF Report configuration ({title}) was found. Submit to remove it and install it again."
+      }
+    },
+    "abort": {
+      "remove_failed": "Removing the existing configuration failed. Please try again from Settings > Devices & Services.",
+      "already_configured": "Energy PDF Report is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "No additional options are available."
+      }
+    }
+  }
+}

--- a/custom_components/energy_pdf_report/translations/fr.json
+++ b/custom_components/energy_pdf_report/translations/fr.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "step": {
+      "reinstall_confirm": {
+        "title": "Remplacer la configuration existante",
+        "description": "Une configuration Energy PDF Report (« {title} ») est déjà présente. Validez pour la supprimer et la réinstaller."
+      }
+    },
+    "abort": {
+      "remove_failed": "La suppression de l'ancienne configuration a échoué. Réessayez depuis Paramètres > Appareils et services.",
+      "already_configured": "Energy PDF Report est déjà configuré."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Aucune option supplémentaire n'est disponible."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reinstall confirmation step in the config flow so an existing entry can be removed before creating a new one
- update YAML import handling to abort when the integration is already configured
- provide English and French translations for the new confirmation step and errors

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d3cd471198832097dfc97d7ecc03a3