### PR TITLE
Wrap metadata retrieval in executor job

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -295,9 +295,8 @@ async def _collect_statistics(
             "Le composant recorder doit être actif pour générer le rapport."
         ) from err
 
-    metadata = await instance.async_add_executor_job(
-        partial(recorder_statistics.get_metadata, hass, statistic_ids)
-    )
+    metadata_job = partial(recorder_statistics.get_metadata, hass, statistic_ids)
+    metadata = await instance.async_add_executor_job(metadata_job)
 
     stats_map = await instance.async_add_executor_job(
         recorder_statistics.statistics_during_period,


### PR DESCRIPTION
## Summary
- wrap recorder statistics metadata retrieval in a partial before submitting it to the executor

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d2ee6aecd48320b14e20ba7c1cfc4e