### PR TITLE
Add options flow handler for energy PDF integration

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -7,6 +7,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
@@ -78,8 +79,8 @@ class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.ConfigFlowResult:
-        """Gérer l'étape initiale du flux d'options."""
+    ) -> FlowResult:
+        """Gérer l'étape initiale du flux d'options (aucune option disponible)."""
 
         if user_input is not None:
             return self.async_create_entry(title="", data={})

--- a/custom_components/energy_pdf_report/translations/en.json
+++ b/custom_components/energy_pdf_report/translations/en.json
@@ -16,7 +16,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "No additional options are available."
+        "description": "No additional options are currently available."
       }
     }
   }

--- a/custom_components/energy_pdf_report/translations/fr.json
+++ b/custom_components/energy_pdf_report/translations/fr.json
@@ -16,7 +16,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "Aucune option supplémentaire n'est disponible."
+        "description": "Aucune option supplémentaire n'est disponible pour le moment."
       }
     }
   }


### PR DESCRIPTION
## Summary
- add the FlowResult type import and update the options flow handler to clarify no options are provided
- adjust English and French option-step descriptions to mention that no settings are currently available

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d3d3ad831083209de88a46b293a75d