### PR TITLE
Render energy PDF charts with native fpdf2 graphics

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -45,7 +45,7 @@ from .const import (
     SERVICE_GENERATE_REPORT,
     VALID_PERIODS,
 )
-from .pdf import EnergyPDFBuilder, TableConfig
+from .pdf import EnergyPDFBuilder, TableConfig, _decorate_category
 
 if TYPE_CHECKING:
     from homeassistant.components.energy.data import EnergyPreferences
@@ -938,6 +938,25 @@ def _calculate_totals(
     return totals
 
 
+def _discover_logo_candidate(output_dir: Path) -> Path | None:
+    """Rechercher un logo optionnel à intégrer dans la page de garde."""
+
+    candidates: list[Path] = []
+    search_dirs = {output_dir, Path(__file__).resolve().parent}
+
+    parent = output_dir.parent
+    if parent != output_dir:
+        search_dirs.add(parent)
+
+    for directory in search_dirs:
+        for filename in ("logo.png", "logo.jpg", "logo.jpeg"):
+            candidate = directory / filename
+            if candidate.exists():
+                candidates.append(candidate)
+
+    return candidates[0] if candidates else None
+
+
 def _build_pdf(
     metrics: list[MetricDefinition],
     totals: dict[str, float],
@@ -992,47 +1011,65 @@ def _build_pdf(
 
     file_path = output_dir / filename
 
-    builder = EnergyPDFBuilder(PDF_TITLE)
-    if dashboard_label:
-        builder.add_paragraph(f"Tableau d'énergie : {dashboard_label}", bold=True)
-    builder.add_paragraph(
-        (
-            "Période analysée : "
-            f"{display_start.strftime('%d/%m/%Y')} → {display_end.strftime('%d/%m/%Y')}"
-        ),
-        bold=True,
-    )
-    builder.add_paragraph(f"Granularité des statistiques : {bucket}")
-    builder.add_paragraph(
-        f"Rapport généré le : {generated_at.strftime('%d/%m/%Y %H:%M')}"
-    )
-    builder.add_paragraph(
-        "Les totaux représentent la variation relevée dans le tableau de bord"
-        " énergie sur la période sélectionnée."
-    )
-    builder.add_paragraph(
-        "Les valeurs négatives indiquent un flux exporté ou une compensation."
-    )
-    builder.add_paragraph(
-        (
-            "Statistiques incluses selon la configuration du tableau de bord énergie : "
-            f"{len(metrics)}"
-        )
+    period_label = f"{display_start.strftime('%d/%m/%Y')} → {display_end.strftime('%d/%m/%Y')}"
+    logo_path = _discover_logo_candidate(output_dir)
+    builder = EnergyPDFBuilder(
+        PDF_TITLE,
+        period_label=period_label,
+        generated_at=generated_at,
+        logo_path=logo_path,
     )
 
-    summary_rows = _prepare_summary_rows(metrics, totals, metadata)
-    summary_widths = builder.compute_column_widths((0.6, 0.25, 0.15))
+    cover_details = [
+        f"Période : {period_label}",
+        f"Granularité des statistiques : {bucket}",
+        f"Statistiques incluses : {len(metrics)}",
+        f"Rapport généré le : {generated_at.strftime('%d/%m/%Y %H:%M')}",
+    ]
+    if dashboard_label:
+        cover_details.insert(1, f"Tableau d'énergie : {dashboard_label}")
+
+    builder.add_cover_page(
+        subtitle=(
+            f"Rapport énergie du {display_start.strftime('%d/%m/%Y')} "
+            f"au {display_end.strftime('%d/%m/%Y')}"
+        ),
+        details=cover_details,
+    )
+
+    builder.add_section_title("Résumé global")
+    builder.add_paragraph(
+        "Cette section présente les totaux consolidés sur la période analysée."
+    )
+
+    summary_rows, summary_series = _prepare_summary_rows(metrics, totals, metadata)
+    summary_widths = builder.compute_column_widths((0.55, 0.27, 0.18))
     builder.add_table(
         TableConfig(
             title="Synthèse par catégorie",
             headers=("Catégorie", "Total", "Unité"),
             rows=summary_rows,
             column_widths=summary_widths,
+            emphasize_rows=list(range(len(summary_rows))),
         )
     )
 
+    builder.add_paragraph(
+        "Les totaux correspondent à la variation mesurée dans le tableau de bord"
+        " énergie sur la période sélectionnée."
+    )
+    builder.add_paragraph(
+        "Les valeurs négatives indiquent un flux exporté ou une compensation."
+    )
+
+    builder.add_section_title("Analyse par catégorie / source")
+    builder.add_paragraph(
+        "Chaque statistique suivie est listée avec sa contribution précise afin de"
+        " faciliter l'analyse fine par origine ou type de consommation."
+    )
+
     detail_rows = _prepare_detail_rows(metrics, totals, metadata)
-    detail_widths = builder.compute_column_widths((0.26, 0.45, 0.17, 0.12))
+    detail_widths = builder.compute_column_widths((0.26, 0.44, 0.18, 0.12))
     builder.add_table(
         TableConfig(
             title="Détail des statistiques",
@@ -1040,6 +1077,44 @@ def _build_pdf(
             rows=detail_rows,
             column_widths=detail_widths,
         )
+    )
+
+    if summary_series:
+        builder.add_paragraph(
+            "La visualisation suivante met en avant la répartition des flux"
+            " pour chaque catégorie suivie et matérialise l'équilibre"
+            " production / consommation."
+        )
+        builder.add_chart("Répartition par catégorie", summary_series)
+
+    builder.add_section_title("Conclusion")
+
+    if summary_series:
+        units = {unit for _, _, unit in summary_series if unit}
+        unit_label = units.pop() if len(units) == 1 else None
+        total_value = sum(value for _, value, _ in summary_series)
+        formatted_total = _format_number(total_value)
+        if unit_label:
+            formatted_total = f"{formatted_total} {unit_label}"
+        builder.add_paragraph(
+            f"Le flux net observé sur la période atteint {formatted_total}.",
+            bold=True,
+        )
+
+        dominant_category, dominant_value, dominant_unit = max(
+            summary_series, key=lambda item: abs(item[1])
+        )
+        formatted_dominant = _format_number(dominant_value)
+        if dominant_unit:
+            formatted_dominant = f"{formatted_dominant} {dominant_unit}"
+        builder.add_paragraph(
+            "La catégorie la plus significative est "
+            f"{dominant_category} avec {formatted_dominant}."
+        )
+
+    builder.add_paragraph(
+        "Pour approfondir l'évolution temporelle et comparer les périodes,"
+        " référez-vous au tableau de bord Énergie de Home Assistant."
     )
 
     builder.add_footer(f"Chemin du fichier : {file_path}")
@@ -1052,8 +1127,8 @@ def _prepare_summary_rows(
     metrics: Iterable[MetricDefinition],
     totals: dict[str, float],
     metadata: dict[str, tuple[int, StatisticMetaData]],
-) -> list[tuple[str, str, str]]:
-    """Préparer les lignes du tableau de synthèse."""
+) -> tuple[list[tuple[str, str, str]], list[tuple[str, float, str]]]:
+    """Préparer les lignes du tableau de synthèse et la série pour les graphiques."""
 
     summary: dict[tuple[str, str], float] = defaultdict(float)
 
@@ -1066,14 +1141,17 @@ def _prepare_summary_rows(
         summary[key] += total
 
     rows: list[tuple[str, str, str]] = []
+    series: list[tuple[str, float, str]] = []
     for (category, unit), value in sorted(
         summary.items(), key=lambda item: (-abs(item[1]), item[0])
     ):
         if abs(value) < 1e-6:
             continue
-        rows.append((category, _format_number(value), unit))
+        decorated = _decorate_category(category)
+        rows.append((decorated, _format_number(value), unit))
+        series.append((decorated, value, unit))
 
-    return rows
+    return rows, series
 
 
 def _prepare_detail_rows(

--- a/custom_components/energy_pdf_report/manifest.json
+++ b/custom_components/energy_pdf_report/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "documentation": "https://example.com",
   "requirements": ["fpdf2>=2.8.4"],
-  "codeowners": [@Villersfr2],
+  "codeowners": ["@Villersfr2"],
   "iot_class": "local_polling",
   "integration_type": "helper",
   "config_flow": true

--- a/custom_components/energy_pdf_report/pdf.py
+++ b/custom_components/energy_pdf_report/pdf.py
@@ -5,22 +5,55 @@ from __future__ import annotations
 import base64
 import zlib
 from dataclasses import dataclass
-
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
 from typing import Iterable, Sequence
 
 from fpdf import FPDF
 
 from .font_data import FONT_DATA
 
-
 FONT_FAMILY = "DejaVuSans"
 _FONT_FILES: dict[str, str] = {
     "": "DejaVuSans.ttf",
     "B": "DejaVuSans-Bold.ttf",
 }
+
+PRIMARY_COLOR = (46, 134, 193)
+HEADER_TEXT_COLOR = (255, 255, 255)
+TEXT_COLOR = (33, 37, 41)
+LIGHT_TEXT_COLOR = (110, 117, 126)
+BORDER_COLOR = (222, 230, 236)
+ZEBRA_COLORS = ((255, 255, 255), (245, 249, 252))
+TOTAL_FILL_COLOR = (235, 239, 243)
+TOTAL_TEXT_COLOR = (87, 96, 106)
+SECTION_SPACING = 6
+CHART_BACKGROUND = (245, 249, 253)
+BAR_TRACK_COLOR = (226, 235, 243)
+BAR_BORDER_COLOR = (202, 214, 223)
+
+_CATEGORY_COLORS: tuple[tuple[str, tuple[int, int, int]], ...] = (
+    ("solaire", (241, 196, 15)),
+    ("électricité", (52, 152, 219)),
+    ("réseau", (52, 152, 219)),
+    ("consommation", (46, 134, 193)),
+    ("production", (39, 174, 96)),
+    ("gaz", (231, 76, 60)),
+    ("eau", (26, 188, 156)),
+    ("batterie", (155, 89, 182)),
+)
+
+_CATEGORY_ICON_HINTS: tuple[tuple[str, str], ...] = (
+    ("solaire", "🌞"),
+    ("réseau", "⚡"),
+    ("électricité", "⚡"),
+    ("consommation", "⚡"),
+    ("appareil", "🔌"),
+    ("gaz", "🔥"),
+    ("eau", "💧"),
+    ("batterie", "🔋"),
+)
 
 
 def _decode_font(encoded: str) -> bytes:
@@ -67,7 +100,6 @@ def _register_unicode_fonts(pdf: FPDF) -> _TemporaryFontCache | None:
     return cache
 
 
-
 @dataclass(slots=True)
 class TableConfig:
     """Configuration d'un tableau à insérer dans le PDF."""
@@ -76,39 +108,319 @@ class TableConfig:
     headers: Sequence[str]
     rows: Iterable[Sequence[str]]
     column_widths: Sequence[float] | None = None
+    emphasize_rows: Sequence[int] | None = None
+
+
+class EnergyReportPDF(FPDF):
+    """PDF thématisé avec en-tête et pied de page personnalisés."""
+
+    def __init__(self, title: str, period_label: str, generated_at: datetime) -> None:
+        super().__init__()
+        self.report_title = title
+        self.period_label = period_label
+        self.generated_at = generated_at
+        self._suppress_header = False
+        self._suppress_footer = False
+        self.set_margins(15, 22, 15)
+
+    def header(self) -> None:  # pragma: no cover - géré par fpdf
+        if self._suppress_header:
+            return
+
+        available_width = self.w - self.l_margin - self.r_margin
+        self.set_xy(self.l_margin, 12)
+        self.set_fill_color(*PRIMARY_COLOR)
+        self.set_text_color(*HEADER_TEXT_COLOR)
+        self.set_draw_color(*PRIMARY_COLOR)
+        self.set_font(FONT_FAMILY, "B", 12)
+        self.cell(available_width, 8, self.report_title, border=0, ln=1, fill=True)
+        self.set_font(FONT_FAMILY, "", 9)
+        self.cell(available_width, 6, self.period_label, border=0, ln=1, fill=True)
+        self.ln(3)
+        self.set_text_color(*TEXT_COLOR)
+        self.set_draw_color(*BORDER_COLOR)
+
+    def footer(self) -> None:  # pragma: no cover - géré par fpdf
+        if self._suppress_footer:
+            return
+
+        self.set_y(-15)
+        self.set_font(FONT_FAMILY, "", 9)
+        self.set_text_color(*LIGHT_TEXT_COLOR)
+        self.cell(0, 5, f"Page {self.page_no()} sur {{nb}}", align="L")
+        self.cell(0, 5, f"Généré le {self.generated_at.strftime('%d/%m/%Y %H:%M')}", align="R")
+        self.set_text_color(*TEXT_COLOR)
 
 
 class EnergyPDFBuilder:
-    """Constructeur simplifié de rapports PDF."""
+    """Constructeur simplifié de rapports PDF professionnels."""
 
-    def __init__(self, title: str) -> None:
+    def __init__(
+        self,
+        title: str,
+        period_label: str,
+        generated_at: datetime,
+        logo_path: str | Path | None = None,
+    ) -> None:
         """Initialiser le générateur de PDF."""
-        self._font_cache = _TemporaryFontCache()
-        self._pdf = FPDF()
-        self._pdf.set_auto_page_break(auto=True, margin=15)
-        self._pdf.add_page()
 
+        self._pdf = EnergyReportPDF(title, period_label, generated_at)
+        self._pdf.set_auto_page_break(auto=True, margin=18)
+        self._pdf.alias_nb_pages()
         self._font_cache = _register_unicode_fonts(self._pdf)
-
+        self._logo_path = self._validate_logo(logo_path)
+        self._content_started = False
         self._pdf.set_title(title)
         self._pdf.set_creator("Home Assistant")
         self._pdf.set_author("energy_pdf_report")
-        self._pdf.set_font(FONT_FAMILY, "B", 16)
-        self._pdf.cell(0, 10, title, ln=True)
-        self._pdf.ln(2)
+        self._default_text_color = TEXT_COLOR
 
     @property
     def _available_width(self) -> float:
         """Retourner la largeur disponible pour le contenu."""
+
         return self._pdf.w - self._pdf.l_margin - self._pdf.r_margin
+
+    def add_cover_page(
+        self,
+        subtitle: str,
+        details: Sequence[str],
+        logo_path: str | Path | None = None,
+    ) -> None:
+        """Ajouter une page de garde élégante."""
+
+        logo = self._validate_logo(logo_path) or self._logo_path
+
+        self._pdf._suppress_header = True
+        self._pdf._suppress_footer = True
+        previous_break = self._pdf.auto_page_break
+        previous_margin = self._pdf.b_margin
+        self._pdf.set_auto_page_break(auto=False)
+        self._pdf.add_page()
+
+        self._pdf.set_text_color(*PRIMARY_COLOR)
+        self._pdf.set_font(FONT_FAMILY, "B", 28)
+        self._pdf.set_y(70)
+
+        if logo and logo.exists():
+            width = min(self._available_width * 0.6, 140)
+            x_position = (self._pdf.w - width) / 2
+            self._pdf.image(str(logo), x=x_position, w=width)
+            self._pdf.ln(65)
+        else:
+            self._pdf.ln(30)
+
+        self._pdf.cell(0, 16, self._pdf.report_title, align="C", ln=True)
+
+        self._pdf.set_font(FONT_FAMILY, "", 14)
+        self._pdf.set_text_color(*TEXT_COLOR)
+        self._pdf.cell(0, 10, subtitle, align="C", ln=True)
+        self._pdf.ln(10)
+
+        self._pdf.set_font(FONT_FAMILY, "", 11)
+        for line in details:
+            self._pdf.cell(0, 8, line, align="C", ln=True)
+
+        self._pdf.set_auto_page_break(auto=previous_break, margin=previous_margin)
+        self._pdf._suppress_header = False
+        self._pdf._suppress_footer = False
+        self._content_started = False
+
+    def add_section_title(self, text: str) -> None:
+        """Ajouter un titre de section coloré."""
+
+        self._ensure_content_page()
+        self._ensure_space(10)
+        self._pdf.set_text_color(*PRIMARY_COLOR)
+        self._pdf.set_font(FONT_FAMILY, "B", 15)
+        self._pdf.cell(0, 10, text, ln=True)
+        self._pdf.ln(2)
+        self._pdf.set_text_color(*self._default_text_color)
 
     def add_paragraph(self, text: str, bold: bool = False, size: int = 11) -> None:
         """Ajouter un paragraphe simple."""
+
+        self._ensure_content_page()
         font_style = "B" if bold else ""
         self._pdf.set_font(FONT_FAMILY, font_style, size)
-        self._ensure_space(6)
+        self._ensure_space(SECTION_SPACING)
         self._pdf.multi_cell(0, 6, text)
         self._pdf.ln(1)
+
+    def add_table(self, config: TableConfig) -> None:
+        """Ajouter un tableau structuré."""
+
+        headers = list(config.headers)
+        rows = list(config.rows)
+        if not headers:
+            return
+
+        self._ensure_content_page()
+        if config.column_widths is not None:
+            column_widths = list(config.column_widths)
+        else:
+            column_widths = [self._available_width / len(headers)] * len(headers)
+
+        header_height = 8
+        row_height = 7
+        decorate_first_column = bool(headers and "catégorie" in headers[0].lower())
+
+        self._pdf.set_font(FONT_FAMILY, "B", 13)
+        self._ensure_space(header_height + 6)
+        self._pdf.cell(0, 9, config.title, ln=True)
+
+        self._pdf.set_font(FONT_FAMILY, "B", 10)
+        self._pdf.set_fill_color(*PRIMARY_COLOR)
+        self._pdf.set_text_color(*HEADER_TEXT_COLOR)
+        self._pdf.set_draw_color(*BORDER_COLOR)
+        self._draw_row(headers, column_widths, header_height, fill=True)
+
+        self._pdf.set_font(FONT_FAMILY, "", 10)
+        self._pdf.set_text_color(*self._default_text_color)
+
+        if not rows:
+            empty_row = ["Aucune donnée disponible"] + [""] * (len(headers) - 1)
+            self._draw_row(empty_row, column_widths, row_height, fill=True)
+            self._pdf.ln(1)
+            return
+
+        emphasize = set(config.emphasize_rows or [])
+
+        for index, row in enumerate(rows):
+            str_row = ["" if value is None else str(value) for value in row]
+            if decorate_first_column and str_row:
+                str_row[0] = _decorate_category(str_row[0])
+            fill_color = ZEBRA_COLORS[index % 2]
+            text_color = self._default_text_color
+            font_style = ""
+
+            if index in emphasize:
+                fill_color = TOTAL_FILL_COLOR
+                text_color = TOTAL_TEXT_COLOR
+                font_style = "B"
+
+            self._draw_row(
+                str_row,
+                column_widths,
+                row_height,
+                fill=True,
+                fill_color=fill_color,
+                text_color=text_color,
+                font_style=font_style,
+            )
+
+        self._pdf.ln(1)
+        self._pdf.set_text_color(*self._default_text_color)
+
+    def add_chart(
+        self,
+        title: str,
+        series: Sequence[tuple[str, float, str]],
+        ylabel: str | None = None,
+    ) -> None:
+        """Dessiner un graphique en barres/gauges directement avec fpdf2."""
+
+        if not series:
+            return
+
+        values = [value for _, value, _ in series]
+        if not any(abs(value) > 1e-6 for value in values):
+            return
+
+        units = {unit for _, _, unit in series if unit}
+        if ylabel is None and len(units) == 1:
+            (ylabel,) = tuple(units)
+
+        num_bars = len(series)
+        bar_height = 8
+        bar_spacing = 4
+        padding_top = 8
+        padding_bottom = 8
+        chart_height = padding_top + padding_bottom + num_bars * bar_height + max(0, num_bars - 1) * bar_spacing
+
+        self._ensure_content_page()
+        self._ensure_space(chart_height + 20)
+        self._pdf.set_font(FONT_FAMILY, "B", 12)
+        self._pdf.cell(0, 8, title, ln=True)
+        if ylabel:
+            self._pdf.set_font(FONT_FAMILY, "", 9)
+            self._pdf.set_text_color(*LIGHT_TEXT_COLOR)
+            self._pdf.cell(0, 5, f"Unités : {ylabel}", ln=True)
+            self._pdf.set_text_color(*self._default_text_color)
+        else:
+            self._pdf.ln(1)
+
+        chart_left = self._pdf.l_margin
+        chart_width = self._available_width
+        value_width = max(32.0, min(60.0, chart_width * 0.18))
+        label_width = max(45.0, min(90.0, chart_width * 0.38))
+        bar_area_width = chart_width - label_width - value_width - 8
+        if bar_area_width < 70:
+            label_width = max(40.0, chart_width - value_width - 70.0 - 8.0)
+            bar_area_width = chart_width - label_width - value_width - 8
+        if bar_area_width < 60:
+            value_width = max(30.0, chart_width - label_width - 60.0 - 8.0)
+            bar_area_width = chart_width - label_width - value_width - 8
+        bar_area_width = max(55.0, bar_area_width)
+
+        chart_top = self._pdf.get_y()
+        self._pdf.set_fill_color(*CHART_BACKGROUND)
+        self._pdf.set_draw_color(*BORDER_COLOR)
+        self._pdf.rect(chart_left, chart_top, chart_width, chart_height, style="F")
+        self._pdf.rect(chart_left, chart_top, chart_width, chart_height)
+
+        bar_area_left = chart_left + label_width + 4
+        positive_max = max((value for value in values if value > 0), default=0.0)
+        negative_min = min((value for value in values if value < 0), default=0.0)
+
+        if positive_max > 0 and negative_min < 0:
+            total_span = positive_max + abs(negative_min)
+            zero_x = bar_area_left + (abs(negative_min) / total_span) * bar_area_width
+        elif positive_max > 0:
+            zero_x = bar_area_left
+        else:
+            zero_x = bar_area_left + bar_area_width
+
+        positive_span = bar_area_left + bar_area_width - zero_x
+        negative_span = zero_x - bar_area_left
+        positive_scale = positive_span / positive_max if positive_max > 0 else 0
+        negative_scale = negative_span / abs(negative_min) if negative_min < 0 else 0
+
+        self._pdf.set_draw_color(*BAR_BORDER_COLOR)
+        self._pdf.line(zero_x, chart_top, zero_x, chart_top + chart_height)
+
+        current_y = chart_top + padding_top
+        for label, value, unit in series:
+            track_top = current_y
+            category_color = _get_category_color(label)
+            self._pdf.set_fill_color(*BAR_TRACK_COLOR)
+            self._pdf.rect(bar_area_left, track_top, bar_area_width, bar_height, style="F")
+
+            if value >= 0 and positive_scale > 0:
+                bar_width = max(0.5, value * positive_scale)
+                self._pdf.set_fill_color(*category_color)
+                self._pdf.rect(zero_x, track_top, bar_width, bar_height, style="F")
+            elif value < 0 and negative_scale > 0:
+                bar_width = max(0.5, abs(value) * negative_scale)
+                self._pdf.set_fill_color(*category_color)
+                self._pdf.rect(zero_x - bar_width, track_top, bar_width, bar_height, style="F")
+
+            self._pdf.set_draw_color(*BAR_BORDER_COLOR)
+            self._pdf.rect(bar_area_left, track_top, bar_area_width, bar_height)
+
+            self._pdf.set_text_color(*TEXT_COLOR)
+            self._pdf.set_font(FONT_FAMILY, "", 10)
+            label_text = _decorate_category(label)
+            self._pdf.set_xy(chart_left + 4, track_top + 1)
+            self._pdf.cell(label_width - 4, bar_height - 2, label_text, align="L")
+
+            value_text = _format_measure(value, unit)
+            self._pdf.set_xy(bar_area_left + bar_area_width + 4, track_top + 1)
+            self._pdf.cell(value_width, bar_height - 2, value_text, align="R")
+
+            current_y += bar_height + bar_spacing
+
+        self._pdf.set_y(chart_top + chart_height + 4)
 
     def compute_column_widths(self, weights: Sequence[float]) -> list[float]:
         """Convertir des poids relatifs en largeurs exploitables par FPDF."""
@@ -123,55 +435,26 @@ class EnergyPDFBuilder:
         available = self._available_width
         return [(weight / total_weight) * available for weight in weights]
 
-    def add_table(self, config: TableConfig) -> None:
-        """Ajouter un tableau structuré."""
-        headers = list(config.headers)
-        rows = list(config.rows)
-        if not headers:
-            return
-
-        if config.column_widths is not None:
-            column_widths = list(config.column_widths)
-        else:
-            column_widths = [self._available_width / len(headers)] * len(headers)
-
-        header_height = 7
-        row_height = 6
-
-        self._pdf.set_font(FONT_FAMILY, "B", 12)
-        self._ensure_space(header_height + 4)
-        self._pdf.cell(0, 8, config.title, ln=True)
-
-        self._pdf.set_font(FONT_FAMILY, "B", 10)
-        self._draw_row(headers, column_widths, header_height)
-
-        self._pdf.set_font(FONT_FAMILY, "", 10)
-        if not rows:
-            empty_row = ["Aucune donnée disponible"] + [""] * (len(headers) - 1)
-            self._draw_row(empty_row, column_widths, row_height)
-            return
-
-        for row in rows:
-            str_row = ["" if value is None else str(value) for value in row]
-            self._draw_row(str_row, column_widths, row_height)
-
-        self._pdf.ln(1)
-
     def add_footer(self, text: str) -> None:
-        """Ajouter un texte de bas de page léger."""
+        """Ajouter un texte informatif discret en fin de rapport."""
+
+        self._ensure_content_page()
         self._pdf.set_font(FONT_FAMILY, "", 9)
         self._ensure_space(5)
+        self._pdf.set_text_color(*LIGHT_TEXT_COLOR)
         self._pdf.multi_cell(0, 5, text)
+        self._pdf.set_text_color(*self._default_text_color)
 
     def output(self, path: str) -> None:
         """Sauvegarder le PDF."""
+
         try:
             self._pdf.output(path)
         finally:
-            self._cleanup_fonts()
+            self._cleanup_resources()
 
-    def _cleanup_fonts(self) -> None:
-        """Nettoyer le répertoire temporaire de polices."""
+    def _cleanup_resources(self) -> None:
+        """Nettoyer les répertoires temporaires."""
 
         cache = getattr(self, "_font_cache", None)
         if cache is not None:
@@ -179,22 +462,93 @@ class EnergyPDFBuilder:
             self._font_cache = None
 
     def __del__(self) -> None:  # pragma: no cover - best effort cleanup
-        self._cleanup_fonts()
+        self._cleanup_resources()
+
+    def _ensure_content_page(self) -> None:
+        if not self._content_started:
+            self._pdf.add_page()
+            self._content_started = True
 
     def _draw_row(
-        self, row: Sequence[str], column_widths: Sequence[float], height: float
+        self,
+        row: Sequence[str],
+        column_widths: Sequence[float],
+        height: float,
+        *,
+        fill: bool = False,
+        fill_color: tuple[int, int, int] | None = None,
+        text_color: tuple[int, int, int] | None = None,
+        font_style: str = "",
     ) -> None:
         """Dessiner une ligne du tableau."""
+
+        if fill_color is not None:
+            self._pdf.set_fill_color(*fill_color)
+        if text_color is not None:
+            self._pdf.set_text_color(*text_color)
+        self._pdf.set_font(FONT_FAMILY, font_style, 10)
         self._ensure_space(height)
+
         for index, (value, width) in enumerate(zip(row, column_widths)):
             align = "R" if index == len(row) - 1 else "L"
-            self._pdf.cell(width, height, value, border=1, align=align)
+            self._pdf.cell(width, height, value, border=1, align=align, fill=fill)
         self._pdf.ln(height)
 
     def _ensure_space(self, height: float) -> None:
         """Ajouter une page si besoin."""
+
+        self._ensure_content_page()
         if self._pdf.get_y() + height > self._pdf.page_break_trigger:
             self._pdf.add_page()
+
+    def _validate_logo(self, logo_path: str | Path | None) -> Path | None:
+        if not logo_path:
+            return None
+        path = Path(logo_path)
+        if path.exists() and path.is_file():
+            return path
+        return None
+
+
+def _decorate_category(label: str) -> str:
+    """Ajouter une icône appropriée devant une catégorie si disponible."""
+
+    normalized = label.strip()
+    lowered = normalized.lower()
+    for keyword, icon in _CATEGORY_ICON_HINTS:
+        if keyword in lowered and not normalized.startswith(icon):
+            return f"{icon} {normalized}"
+    return normalized
+
+
+def _get_category_color(label: str) -> tuple[int, int, int]:
+    """Choisir une couleur fixe en fonction de la catégorie."""
+
+    lowered = label.lower()
+    for keyword, color in _CATEGORY_COLORS:
+        if keyword in lowered:
+            return color
+    return PRIMARY_COLOR
+
+
+def _format_measure(value: float, unit: str | None) -> str:
+    """Formater une valeur numérique avec unité."""
+
+    formatted = _format_number(value)
+    return f"{formatted} {unit}".strip() if unit else formatted
+
+
+def _format_number(value: float) -> str:
+    """Formater un nombre pour l'affichage dans le PDF."""
+
+    magnitude = abs(value)
+    if magnitude >= 1000:
+        formatted = f"{value:,.0f}"
+    elif magnitude >= 100:
+        formatted = f"{value:,.1f}"
+    else:
+        formatted = f"{value:,.2f}"
+    return formatted.replace(",", " ")
 
 
 __all__ = ["EnergyPDFBuilder", "TableConfig"]


### PR DESCRIPTION
## Summary
- drop the matplotlib requirement and rely solely on fpdf2 for report rendering
- implement fpdf2-based bar and gauge visuals with category colors, formatted values, and shared helpers
- refresh the report narrative to emphasise the résumé global, category analysis with the new chart, and a conclusion section

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d54b7d0c548320ab8199b379396aff